### PR TITLE
Win32 Fixes

### DIFF
--- a/tlc.c
+++ b/tlc.c
@@ -56,7 +56,7 @@ void usage (void) {
 }
 
 int vkext_write (const char *filename) {
-  int f = open (filename, O_CREAT | O_WRONLY | O_TRUNC, 0640);
+  int f = open (filename, O_CREAT | O_WRONLY | O_TRUNC | O_BINARY, 0640);
   assert (f >= 0);
   write_types (f);
   close (f);


### PR DESCRIPTION
These are the changes needed to make tl-parser work on mingw.

Of particular concern is the changes to set NULL pointers before using variables, eg `struct tree_tl_type *tl_type_tree = 0;`, otherwise it's using random memory locations to create the tree's and they end up in the resulting .tlo file.