### PR TITLE
do a correct definition

### DIFF
--- a/portable_endian.h
+++ b/portable_endian.h
@@ -45,11 +45,11 @@
 #	define __LITTLE_ENDIAN LITTLE_ENDIAN
 #	define __PDP_ENDIAN    PDP_ENDIAN
 
-#elif defined(__OpenBSD__)
+#elif defined(__OpenBSD__) || defined(__FreeBSD__)
 
 #	include <sys/endian.h>
 
-#elif defined(__NetBSD__) || defined(__FreeBSD__) || defined(__DragonFly__)
+#elif defined(__NetBSD__) || defined(__DragonFly__)
 
 #	include <sys/endian.h>
 


### PR DESCRIPTION
Part of https://github.com/majn/telegram-purple/issues/260
HISTORY
     The hto*() and *toh() functions first appeared in FreeBSD 5.0, and were
     originally developed by the NetBSD project.

     The encode/decode functions first appeared in FreeBSD 5.1.
